### PR TITLE
Bail out of the script on the first failure.

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -12,15 +12,16 @@ echo Found target library at $FULLPATH
 echo Filename $FILE
 echo Hash $HASH
 
-mkdir -p $TMP
-cd $TMP
-cp $FULLPATH $FILE
-cp $FULLPATH $FILE.orig
-cc -c -fPIC -O2 -pipe -fstack-protector -fno-strict-aliasing -o old_fstat.o $CURDIR/old_fstat.c
-ar x $FULLPATH $STDINNER
-ld -r -o std.xx.o $STDINNER old_fstat.o
-mv std.xx.o $STDINNER
-ar r $FILE $STDINNER
-cp $FILE $FULLPATH
+mkdir -p $TMP || exit 1
+cd $TMP || exit 1
+cp $FULLPATH $FILE || exit 1
+cp $FULLPATH $FILE.orig || exit 1
+cc -c -fPIC -O2 -pipe -fstack-protector -fno-strict-aliasing -o old_fstat.o $CURDIR/old_fstat.c || exit 1
+ar x $FULLPATH $STDINNER || exit 1
+ld -r -o std.xx.o $STDINNER old_fstat.o || exit 1
+mv std.xx.o $STDINNER || exit 1
+ar r $FILE $STDINNER || exit 1
+cp $FILE $FULLPATH || exit 1
+
 echo Rust std patched for ino64!
 echo A copy of the original $FILE is kept in $TMP/


### PR DESCRIPTION
We we can't find a file in the archive, don't try to extract it,
link it, move it, etc. Instead, fail on the first error message: this
makes the failure mode more apparent to the user.